### PR TITLE
Remove universal analytics

### DIFF
--- a/MkDocs/apm_8.11/mkdocs.yml
+++ b/MkDocs/apm_8.11/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Maximo APM Hands On Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "Maximo Asset Performance Management v8.11 Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/apm_8.11
 
 nav:

--- a/MkDocs/apm_8.7/mkdocs.yml
+++ b/MkDocs/apm_8.7/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Maximo APM V8.7 Hands On Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "Maximo Asset Performance Management v8.7 Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/apm_8.7
 
 nav:

--- a/MkDocs/apm_8.8/mkdocs.yml
+++ b/MkDocs/apm_8.8/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Maximo APM V8.8 Hands On Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "Maximo Asset Performance Management v8.8 Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/apm_8.8
 
 nav:

--- a/MkDocs/apm_8.9/mkdocs.yml
+++ b/MkDocs/apm_8.9/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Maximo APM Hands On Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "Maximo Asset Performance Management v8.9 Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/apm_8.9
 
 nav:

--- a/MkDocs/contribute/mkdocs.yml
+++ b/MkDocs/contribute/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Contribute to IBM Maximo Labs
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Jan Ekstrøm & Contributors
 site_description: "How to contribute to the IBM Maximo hands on abs"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/contribute
 
 nav:

--- a/MkDocs/edc_8.11/mkdocs.yml
+++ b/MkDocs/edc_8.11/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Edge Data Collector Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Jan Ekstrøm & Contributors
 site_description: "Maximo Monitor Edge Data Collector Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/edc_8.11
 
 nav:

--- a/MkDocs/hpu_8.6/mkdocs.yml
+++ b/MkDocs/hpu_8.6/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: MAS Health and Predict for Utilities 8.6 Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferriera & Contributors
 site_description: "MAS Health and Predict for Utilities 8.6 Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/hpu_8.6
 
 nav:

--- a/MkDocs/mas_8.6/mkdocs.yml
+++ b/MkDocs/mas_8.6/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: MAS Overview 8.6 Labs
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "Maximo Application Suite Overview 8.6 Overview Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/mas_8.6
 
 nav:

--- a/MkDocs/mas_monitor_connect/mkdocs.yml
+++ b/MkDocs/mas_monitor_connect/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: MAS Monitor Connect Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Mike Lamb
 site_description: "MAS Monitor Connect Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/mas_monitor_connect
 
 nav:

--- a/MkDocs/mas_monitor_hierarchy/mkdocs.yml
+++ b/MkDocs/mas_monitor_hierarchy/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Monitor Hierarchy Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Mike Lamb
 site_description: "Monitor Hierarchy Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/mas_monitor_hierarchy
 
 nav:

--- a/MkDocs/monitor_8.5/mkdocs.yml
+++ b/MkDocs/monitor_8.5/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Maximo Hands on Labs
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "Maximo Hands on Lab for Monitor v8.5"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/monitor_8.5
 
 nav:

--- a/MkDocs/monitor_autoai_8.5/mkdocs.yml
+++ b/MkDocs/monitor_autoai_8.5/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Monitor Auto AI Hands on Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "Maximo Auto AI Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/monitor_autoai_8.5
 
 nav:

--- a/MkDocs/monitor_nodered_csv_importer_1.0/mkdocs.yml
+++ b/MkDocs/monitor_nodered_csv_importer_1.0/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Monitor Node-RED CSV Importer Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Jan Ekstrøm & Contributors
 site_description: "Maximo Monitor Node-RED CSV Importer Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/monitor_nodered_csv_importer_1.0
 
 nav:

--- a/MkDocs/monitor_nodered_csv_importer_2.0/mkdocs.yml
+++ b/MkDocs/monitor_nodered_csv_importer_2.0/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Monitor Node-RED CSV Importer Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Jan Ekstrøm & Contributors
 site_description: "Maximo Monitor Node-RED CSV Importer Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/monitor_nodered_csv_importer_2.0
 
 nav:

--- a/MkDocs/monitor_saas/mkdocs.yml
+++ b/MkDocs/monitor_saas/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Monitor SaaS Labs
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "Maximo Asset Monitor SaaS Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/monitor_saas
 
 nav:

--- a/MkDocs/mvi_saas/mkdocs.yml
+++ b/MkDocs/mvi_saas/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Visual Inspection SaaS Labs
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Cecilia Duffus & Contributors
 site_description: "Visual Inspection SaaS Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/mvi_saas
 
 nav:

--- a/MkDocs/ocp_8.9/mkdocs.yml
+++ b/MkDocs/ocp_8.9/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: MAS 8.9 Deployment Lab
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Arif Ali & Contributors
 site_description: "MAS 8.9 Deployment Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/ocp_8.9
 
 nav:

--- a/MkDocs/sustain_mas/mkdocs.yml
+++ b/MkDocs/sustain_mas/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Environmental Use Cases Labs
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Jan Ekstrøm & Contributors
 site_description: "Maximo Sustainability Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/sustain_mas
 
 nav:

--- a/MkDocs/template_1.0/mkdocs.yml
+++ b/MkDocs/template_1.0/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: Template 1.0 Labs
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Jan Ekstrøm & Contributors
 site_description: "Maximo Template 1.0 Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site/template_1.0
 
 nav:

--- a/MkDocs/toplevel/docs/about.md
+++ b/MkDocs/toplevel/docs/about.md
@@ -37,6 +37,7 @@ If you want to write new labs or improve the existing labs, then find the instru
 
 |Date     |By             | Description                                           |
 |:--------|:--------------|:------------------------------------------------------|
+|2023-10-30|Jan Ekstrøm|Removed deprecated Universal Analytics.|
 |2023-09-25|Jan Ekstrøm|Added the Maximo Monitor Edge Data Collector Lab.|
 |2023-03-24|Mike Lamb & Jan Ekstrøm|Added Monitor Node-RED CSV Importer Lab V2.0|
 |2022-10-18|Jan Ekstrøm|Updated Monitor-Omnio Integration Lab and the Maximo Lab landing page.|

--- a/MkDocs/toplevel/docs/index.md
+++ b/MkDocs/toplevel/docs/index.md
@@ -29,8 +29,6 @@ portfolio.  The labs are in different states of readiness for use shown below. F
 | [Monitor Node-RED CSV Importer V2](/monitor_nodered_csv_importer_2.0/) | [Setup Node-RED Environment](/monitor_nodered_csv_importer_2.0/setup)                              |
 |                                                                        | [Inject device data directly to Monitor](/monitor_nodered_csv_importer_2.0/setup_device)           |
 |                                                                        | [Inject device data through a gateway to Monitor](/monitor_nodered_csv_importer_2.0/setup_gateway) |
-| [Health, Predict and Utilities](/apm_8.9/)                             | [Setup Demonstration](/apm_8.9/build_demo)                                                         |
-|                                                                        | [Overview Task Guide](/apm_8.9/demo_script)                                                        |
 
 
 ### Maximo Application Suite 8.9

--- a/MkDocs/toplevel/docs/index.md
+++ b/MkDocs/toplevel/docs/index.md
@@ -153,7 +153,7 @@ portfolio.  The labs are in different states of readiness for use shown below. F
   [New Lab Template](/template_1.0/)  
 
 ---
-**UPDATED: 2023-09-25**
+**UPDATED: 2023-10-30**
 ---
 
 © 2023 International Business Machines Corporation

--- a/MkDocs/toplevel/mkdocs.yml
+++ b/MkDocs/toplevel/mkdocs.yml
@@ -2,7 +2,6 @@ site_name: IBM Maximo Labs
 site_url: http://maximo-lab.monitordemo4.ibmmam.com/
 site_author: Carlos Ferreira & Contributors
 site_description: "IBM Maximo Hands on Lab"
-google_analytics: ['UA-159649729-1', 'auto']
 site_dir: ../../site
 
 

--- a/build_all_mkdocs.sh
+++ b/build_all_mkdocs.sh
@@ -38,7 +38,6 @@ echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM 
 mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
 echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
 
-
 # Build the MVI Saas level:
 lab=mvi_saas
 cd $root_dir/MkDocs/$lab
@@ -47,7 +46,6 @@ echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM 
 mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
 echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
 
-
 # Build the Maximo Monitor Auto AI 8.5 level:
 lab=monitor_autoai_8.5
 cd $root_dir/MkDocs/$lab
@@ -55,15 +53,6 @@ mkdocs build
 echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM Maximo Labs."
 #mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
 #echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
-
-
-# Build the Maximo Application Suite Overview 8.5 level:
-lab=mas_8.5
-cd $root_dir/MkDocs/$lab
-mkdocs build
-echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM Maximo Labs."
-mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
-echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
 
 # Build the Maximo Application Suite Overview 8.6 level:
 lab=mas_8.6
@@ -129,7 +118,6 @@ echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM 
 mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
 echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
 
-
 # Build the MAS v8.11 deployment for Health Predict and Utilities Lab level:
 lab=apm_8.11
 cd $root_dir/MkDocs/$lab
@@ -137,14 +125,6 @@ mkdocs build
 echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM Maximo Labs."
 mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
 echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
-
-# # Build the MAS deployment on OCP lab level:
-# lab=ocp_8.6
-# cd $root_dir/MkDocs/$lab
-# mkdocs build
-# echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM Maximo Labs."
-# mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
-# echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
 
 # Build the MAS deployment on OCP lab level:
 lab=ocp_8.9
@@ -156,14 +136,6 @@ echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
 
 # Build the Monitor hierarchy level:
 lab=mas_monitor_hierarchy
-cd $root_dir/MkDocs/$lab
-mkdocs build
-echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM Maximo Labs."
-mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
-echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
-
-# Build the Omnio - Monitor integration:
-lab=omnio_8.8
 cd $root_dir/MkDocs/$lab
 mkdocs build
 echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM Maximo Labs."
@@ -187,7 +159,6 @@ mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
 echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
 
 
-
 ########################################################################################
 #### DON't CHANGE THE BELOW MANDATORY SECTION WHICH IS PART OF THE TOPLEVEL CONTENT ####
 ########################################################################################
@@ -207,7 +178,6 @@ mkdocs build
 echo "BUILD_INFO - The $lab labs are build and added under the top level of IBM Maximo Labs."
 mv $root_dir/site/$lab/img/$lab $root_dir/site/img/
 echo "BUILD_INFO - The $lab lab images has been moved under /site/img/$lab."
-
 
 # Start the web server hosting the complete site - then open the following URL in a browser: http://127.0.0.1:8080
 cd $root_dir/site


### PR DESCRIPTION
Google Universal Analytics has been deprecated and is now removed from all mkdocs.yml files, i.e. for all labs in Maximo Labs.